### PR TITLE
Explicit Result type

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,13 +35,13 @@
 #[macro_export]
 macro_rules! formatx {
     ($template: expr) => {
-        || -> Result<String, $crate::Error> {
+        || -> std::result::Result<String, $crate::Error> {
             Ok($crate::Template::new($template)?.text()?)
         }()
     };
 
     ($template: expr, $($values: tt)*) => {
-        || -> Result<String, $crate::Error> {
+        || -> std::result::Result<String, $crate::Error> {
             let mut template = $crate::Template::new($template)?;
             $crate::_formatx_internal!(template, $($values)*);
             template.text()


### PR DESCRIPTION
I ran into a problem where the code using the formatx! macro has its own Result type, which created a confilct with the Result type being used in the macro. This patch solves my issue.