### PR TITLE
Fixed clippy warnings.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,7 +36,7 @@
 macro_rules! formatx {
     ($template: expr) => {
         || -> ::std::result::Result<String, $crate::Error> {
-            Ok($crate::Template::new($template)?.text()?)
+            $crate::Template::new($template)?.text()
         }()
     };
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -221,7 +221,7 @@ impl Template {
     where
         T: Display + Debug,
     {
-        self.replace_with_callback(&self.position.to_string(), value, |formatted_value, _| {
+        self.replace_with_callback(self.position.to_string(), value, |formatted_value, _| {
             formatted_value
         });
         self.position += 1;


### PR DESCRIPTION
The formatx macro isn't actually caught by clippy when run on the repo, but is caught when running it on a project that uses formatx.